### PR TITLE
add context to include in the generated data

### DIFF
--- a/contexts/group.jsonld
+++ b/contexts/group.jsonld
@@ -1,0 +1,84 @@
+{
+  "@context": {
+    "rdf":  "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "s": "http://schema.org/",
+    "w3c": "https://www.w3.org/ns/w3c#",
+    "@vocab": "x-todo:",
+
+    "@language": "en",
+
+    "creation-date": {
+      "@id": "s:dateCreated",
+      "@type": "xsd:date"
+    },
+    "start-date": {
+      "@id": "s:startDate",
+      "@type": "xsd:date"
+    },
+    "end-date": {
+      "@id": "s:endDate",
+      "@type": "xsd:date"
+    },
+    "close-date": {
+      "@id": "s:dateDeleted",
+      "@type": "xsd:date"
+    },
+    "description": "s:description",
+    "discr": null,
+    "group-type": {
+      "@id": "rdf:type",
+      "@type": "@vocab",
+      "@context": {
+        "bg": "w3c:BusinessGroup",
+        "cg": "w3c:CommunityGroup",
+        "ig": "w3c:InterestGroup",
+        "other": "w3c:OtherGroup",
+        "tf": "w3c:TaskForce",
+        "wg": "w3c:WorkingGroup"
+      }
+    },
+    "id": "w3c:id",
+    "identifier": {
+      "@id": "w3c:groupId",
+      "@language": null
+    },
+    "internal": null,
+    "is_closed": "w3c:isClosed",
+    "members": "s:member",
+    "name": "s:name",
+    "participants_list_public": "w3c:hasPublicParticipantList",
+    "services": {
+      "@id": "https://www.w3.org/ns/did#service",
+      "@context": [
+        null,
+        "./service.jsonld"
+      ]
+    },
+    "shortname": {
+      "@id": "w3c:shortname",
+      "@language": null
+    },
+    "tr-publisher": "w3c:trPublisher",
+    "_links": {
+      "@id": "@nest",
+      "@context": {
+        "href": "@id",
+        "self": "@nest",
+
+        "homepage": "s:mainEntityOfPage",
+        "join": "w3c:joinPage",
+        "pp-status": "w3c:iprPage",
+
+        "active-charter": "w3c:link:active-charter",
+        "chairs": "w3c:link:chairs",
+        "charters": "w3c:link:charters",
+        "participations": "w3c:link:participations",
+        "services": "w3c:link:services",
+        "specifications": "w3c:link:specifications",
+        "team-contacts": "w3c:link:team-contacts",
+        "users": "w3c:link:users"
+      }
+    }
+  }
+}

--- a/contexts/group.jsonld
+++ b/contexts/group.jsonld
@@ -20,7 +20,7 @@
       "@id": "s:endDate",
       "@type": "xsd:date"
     },
-    "close-date": {
+    "closed_date": {
       "@id": "s:dateDeleted",
       "@type": "xsd:date"
     },
@@ -59,7 +59,9 @@
       "@id": "w3c:shortname",
       "@language": null
     },
+    "spec-publisher": "w3c:specPublisher",
     "tr-publisher": "w3c:trPublisher",
+    "type": null,
     "_links": {
       "@id": "@nest",
       "@context": {

--- a/contexts/repository.jsonld
+++ b/contexts/repository.jsonld
@@ -1,0 +1,35 @@
+{
+  "@context": {
+    "rdf":  "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "s": "http://schema.org/",
+    "w3c": "https://www.w3.org/ns/w3c#",
+    "@vocab": "x-todo:",
+
+    "@language": "en",
+
+    "name": {
+      "@id": "s:identifier",
+      "@language": null
+    },
+    "homepageUrl": {
+      "@id": "s:url",
+      "@type": "@id"
+    },
+    "description": "s:description",
+    "isArchived": "w3c:isArchived",
+    "isPrivate": "w3c:isPrivate",
+    "owner": {
+      "@id": "s:owner",
+      "@context": {
+        "@base": "https://github.com/",
+        "login": "@id",
+        "description": "s:description"
+      }
+    },
+    "w3cjson": {
+      "@id": "w3cjson",
+      "@type": "@json"
+    }
+  }
+}

--- a/contexts/repository.jsonld
+++ b/contexts/repository.jsonld
@@ -8,6 +8,7 @@
 
     "@language": "en",
 
+    "html_url": "@id",
     "name": {
       "@id": "s:identifier",
       "@language": null
@@ -22,8 +23,7 @@
     "owner": {
       "@id": "s:owner",
       "@context": {
-        "@base": "https://github.com/",
-        "login": "@id",
+        "login": "s:identifier",
         "description": "s:description"
       }
     },

--- a/contexts/repository.jsonld
+++ b/contexts/repository.jsonld
@@ -23,12 +23,14 @@
     "owner": {
       "@id": "s:owner",
       "@context": {
-        "login": "s:identifier",
-        "description": "s:description"
+        "login": {
+          "@id": "w3c:githubId",
+          "@language": null
+        }
       }
     },
     "w3cjson": {
-      "@id": "w3cjson",
+      "@id": "w3c:w3cjson",
       "@type": "@json"
     }
   }

--- a/contexts/repository.jsonld
+++ b/contexts/repository.jsonld
@@ -8,7 +8,7 @@
 
     "@language": "en",
 
-    "html_url": "@id",
+    "url": "@id",
     "name": {
       "@id": "s:identifier",
       "@language": null

--- a/contexts/service.jsonld
+++ b/contexts/service.jsonld
@@ -1,0 +1,53 @@
+{
+  "@context": {
+    "rdf":  "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "s": "http://schema.org/",
+    "w3c": "https://www.w3.org/ns/w3c#",
+    "@vocab": "x-todo:",
+
+    "@language": "en",
+
+    "details": {
+      "@id": "@nest",
+      "@context": {
+        "closed": "w3c:isClosed",
+        "link": {
+          "@id": "s:serviceUrl",
+          "@type": "@id"
+        },
+        "longdesc": "s:description",
+        "shortdesc": "rdfs:label",
+        "type": {
+          "@id": "rdf:type",
+          "@type": "@vocab",
+          "@context": {
+            "blog": "w3c:BlogService",
+            "chat": "w3c:ChatService",
+            "forum": "w3c:ForumService",
+            "lists": "w3c:ListsService",
+            "mastodon": "w3c:MastodonService",
+            "other": "w3c:OtherService",
+            "repository": "w3c:RepositoryService",
+            "rss": "w3c:RssService",
+            "slack": "w3c:SlackService",
+            "tracker": "w3c:TrackerService",
+            "wiki": "w3c:WikiService",
+            "x": "w3c:ServiceX"
+          }
+        },
+        "_links": {
+          "@id": "@nest",
+          "@context": {
+            "href": "@id",
+            "self": "@nest",
+
+            "groups": "w3c:link:groups"
+          }
+        }
+      }
+    },
+    "href": null,
+    "title": "s:name"
+  }
+}


### PR DESCRIPTION
Those context files can be used to turn the files in w3c/groups into JSON-LD.

More precisely:
* `w3c-groups.json`: each object in the array should be extended with `"@context": "./contexts/group.jsonld"`
* `all-repositories.json`: each object in the array should be extended with `"@context": "./contexts/repository.jsonld"`
* `{group}/repositories.json` / `{group}/others.json`:
    each object in the array should be extended with `"@context": "../../contexts/repository.jsonld"`
* `{group}/group.json`: the object should be extended with `"@context": "../../contexts/group.jsonld"`

(all the above assuming that the `contexts` folder is copied at the root of the `w3c/groups` repo).